### PR TITLE
add prop-types package

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,11 +41,11 @@ var MasonryInfiniteScroller = (_temp = _class = function (_Component) {
   _createClass(MasonryInfiniteScroller, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
-      var _props = this.props;
-      var packed = _props.packed;
-      var sizes = _props.sizes;
-      var children = _props.children;
-      var position = _props.position;
+      var _props = this.props,
+          packed = _props.packed,
+          sizes = _props.sizes,
+          children = _props.children,
+          position = _props.position;
 
 
       var instance = (0, _bricks2.default)({
@@ -81,7 +81,11 @@ var MasonryInfiniteScroller = (_temp = _class = function (_Component) {
       }
 
       if (prevProps.children.length !== children.length) {
-        return instance.update();
+        if (this.props.pack) {
+          return instance.pack();
+        } else {
+          return instance.update();
+        }
       }
     }
   }, {
@@ -94,16 +98,16 @@ var MasonryInfiniteScroller = (_temp = _class = function (_Component) {
     value: function render() {
       var _this2 = this;
 
-      var _props2 = this.props;
-      var className = _props2.className;
-      var style = _props2.style;
-      var children = _props2.children;
-      var pageStart = _props2.pageStart;
-      var loadMore = _props2.loadMore;
-      var hasMore = _props2.hasMore;
-      var loader = _props2.loader;
-      var threshold = _props2.threshold;
-      var useWindow = _props2.useWindow;
+      var _props2 = this.props,
+          className = _props2.className,
+          style = _props2.style,
+          children = _props2.children,
+          pageStart = _props2.pageStart,
+          loadMore = _props2.loadMore,
+          hasMore = _props2.hasMore,
+          loader = _props2.loader,
+          threshold = _props2.threshold,
+          useWindow = _props2.useWindow;
 
       return _react2.default.createElement(
         _reactInfiniteScroller2.default,
@@ -137,6 +141,7 @@ var MasonryInfiniteScroller = (_temp = _class = function (_Component) {
   hasMore: _react.PropTypes.bool,
   loader: _react.PropTypes.element,
   loadMore: _react.PropTypes.func,
+  pack: _react.PropTypes.bool,
   packed: _react.PropTypes.string,
   pageStart: _react.PropTypes.number,
   position: _react.PropTypes.bool,
@@ -146,6 +151,7 @@ var MasonryInfiniteScroller = (_temp = _class = function (_Component) {
   useWindow: _react.PropTypes.bool
 }, _class.defaultProps = {
   className: '',
+  pack: false,
   packed: 'data-packed',
   position: true,
   sizes: [{ columns: 1, gutter: 20 }, { mq: '768px', columns: 2, gutter: 20 }, { mq: '1024px', columns: 3, gutter: 20 }],

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://skoob13.github.io/react-masonry-infinite",
   "dependencies": {
     "bricks.js": "^1.7.0",
+    "prop-types": "^15.5.10",
     "react-infinite-scroller": "^0.2.9"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Bricks from 'bricks.js';
 import InfiniteScroll from 'react-infinite-scroller';
 


### PR DESCRIPTION
React broke out prop-types into a separate package and started outputting a console error in React 15.5