### PR TITLE
Add initialLoad options

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ import MasonryInfiniteScroller from 'react-masonry-infinite';
 |       position        |       Boolean      |         `true`       | A Booleanean indicating that the grid items should be positioned using the `top` and `left` CSS properties. |
 |       style        |       Object      |         `{}`       | The inline style |
 |  pageStart    |      Number     |      `0`    | The page number corresponding to the initial `items`, defaults to `0` which means that for the first loading, loadMore will be called with `1` |
+|  initialLoad    |      Boolean     |      `true`    | Booleanean stating whether the component should load the first set of items. |
 |  loadMore    |      Function     |      `(pageToLoad) => {}`    | This function is called when the user scrolls down and we need to load items |
 |  hasMore    |      Boolean     |      `true`    | Booleanean stating whether there are more items to be loaded. Event listeners are removed if `false` |
 |  loader    |      DOMNode     |      `null`    | Loader element to be displayed while loading items |

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ export default class MasonryInfiniteScroller extends Component {
     children: PropTypes.arrayOf(PropTypes.element).isRequired,
     className: PropTypes.string,
     element: PropTypes.string,
+    initialLoad: PropTypes.bool,
     hasMore: PropTypes.bool,
     loadMore: PropTypes.func,
     loader: PropTypes.element,
@@ -23,6 +24,7 @@ export default class MasonryInfiniteScroller extends Component {
 
   static defaultProps = {
     className: '',
+    initialLoad: true,
     pack: false,
     packed: 'data-packed',
     position: true,
@@ -99,6 +101,7 @@ export default class MasonryInfiniteScroller extends Component {
       children,
       className,
       element,
+      initialLoad,
       hasMore,
       loadMore,
       loader,
@@ -111,6 +114,7 @@ export default class MasonryInfiniteScroller extends Component {
     return (
       <InfiniteScroll
         element={element}
+        initialLoad={initialLoad}
         hasMore={hasMore}
         loadMore={loadMore}
         loader={loader}


### PR DESCRIPTION
First of all, I want to say thank you for creating this awesome library, it makes my UI become more beautiful and flexible. During using time, I find out that we should have to add more options to improve it. 

This PR adds an option to on/off initial load at the first time. If we always have initial load by default, some time it will load two page at the first time. For example in my case, it load page 1 and page 2 at the first time and sometime result of page 2 return before page 1, the mismatch occur.

![image](https://user-images.githubusercontent.com/13161875/28911904-4fc4de04-785c-11e7-9578-1f50bec86832.png)

Please help to review my pr and tell me if we can improve it someway.

Thanks!