### PR TITLE
check for state on componentWillUnmount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,9 @@ export default class MasonryInfiniteScroller extends Component {
   }
 
   componentWillUnmount() {
-    this.state.instance.resize(false);
+    if (this.state) {
+      this.state.instance.resize(false);
+    }
   }
 
   setContainerRef = (component) => {


### PR DESCRIPTION
Under specific circumstances (such as when rendering this component inside of a `Gateway` component  from [react-gateway](https://github.com/cloudflare/react-gateway)), `componentWillUnmount` may get fired _before_ `this.state` is initialized (since `setState()` is async).

This produces an exception:

![image](https://user-images.githubusercontent.com/418473/30244405-b6547d6a-9593-11e7-9b05-d528b0c2d6ea.png)

![image](https://user-images.githubusercontent.com/418473/30244401-8a6a0f12-9593-11e7-8385-49a4d0a6efad.png)

This PR adds a check to the `componentWillUnmount` method, so that we don't attempt to access the state if it's not initialized.
